### PR TITLE
Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _MacOS only_
 
 This application fetches spotify status with osascript from the Spotify Desktop application and displays the result in the system tray.
 
-## How to use
+## How to create the app
 
 - Install go on your machine (`brew install go`)
 
@@ -25,3 +25,11 @@ This application fetches spotify status with osascript from the Spotify Desktop 
 ### Generate icon
 
 You can generate a custom tray icon with `make generate_icon 'path-to-file'` or you can generate the default icon with `make generate_icon_default`.
+
+## How to use the app
+
+Launch the app or from the terminal as a process. A system tray should appear with information about current track data from the Spotify desktop app. You can format this information with some on runtime options (not persisted) by clicking on the system tray:
+
+- `Show progress`: show a percentage with how far the track has progressed (default: `true`)
+- `Show artist first`: show the artist first and then the title (default: `true`)
+- `Use more space`: use `64` characters for artist and `64` characters for track title, otherwise use `20` characters (default: `true`)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can generate a custom tray icon with `make generate_icon 'path-to-file'` or 
 
 ## How to use the app
 
-Launch the app or from the terminal as a process. A system tray should appear with information about current track data from the Spotify desktop app. You can format this information with some on runtime options (not persisted) by clicking on the system tray:
+Launch the app or from the terminal as a process. A system tray should appear with information about current track data from the Spotify desktop app. You can format this information with some options by clicking on the system tray:
 
 - `Show progress`: show a percentage with how far the track has progressed (default: `true`)
 - `Show artist first`: show the artist first and then the title (default: `true`)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"spotify-tray/storage"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ func main() {
 	onExit := func() {
 	}
 
+	storage.Init()
 	systray.Run(onReady, onExit)
 }
 
@@ -128,9 +130,9 @@ func onReady() {
 	systray.SetTitle("Loading...")
 	mLyrics := systray.AddMenuItem("Lyrics", "Search for lyrics online")
 	systray.AddSeparator()
-	mProgress := systray.AddMenuItemCheckbox("Show progress?", "Show Progress", true)
-	mArtistFirst := systray.AddMenuItemCheckbox("Show artist first?", "Show artist first", true)
-	mMoreSpace := systray.AddMenuItemCheckbox("Use more space?", "Use more space", true)
+	mProgress := systray.AddMenuItemCheckbox("Show progress?", "Show Progress", storage.GetHasProgress())
+	mArtistFirst := systray.AddMenuItemCheckbox("Show artist first?", "Show artist first", storage.GetArtistFirst())
+	mMoreSpace := systray.AddMenuItemCheckbox("Use more space?", "Use more space", storage.GetMoreSpace())
 	systray.AddSeparator()
 	mQuitOrig := systray.AddMenuItem("Quit", "Quit the whole app")
 
@@ -154,22 +156,28 @@ func onReady() {
 			case <-mProgress.ClickedCh:
 				if mProgress.Checked() {
 					mProgress.Uncheck()
+					storage.SetHasProgress(false)
 				} else {
 					mProgress.Check()
+					storage.SetHasProgress(true)
 				}
 
 			case <-mArtistFirst.ClickedCh:
 				if mArtistFirst.Checked() {
 					mArtistFirst.Uncheck()
+					storage.SetArtistFirst(false)
 				} else {
 					mArtistFirst.Check()
+					storage.SetArtistFirst(true)
 				}
 
 			case <-mMoreSpace.ClickedCh:
 				if mMoreSpace.Checked() {
 					mMoreSpace.Uncheck()
+					storage.SetMoreSpace(false)
 				} else {
 					mMoreSpace.Check()
+					storage.SetMoreSpace(true)
 				}
 			}
 		}
@@ -178,7 +186,7 @@ func onReady() {
 	go func() {
 		for {
 			currentSpotifyStatus = fetchSpotifyStatus()
-			message := currentSpotifyStatus.Format(mProgress.Checked(), mArtistFirst.Checked(), mMoreSpace.Checked())
+			message := currentSpotifyStatus.Format(storage.GetHasProgress(), storage.GetArtistFirst(), storage.GetMoreSpace())
 			systray.SetTitle(message)
 			time.Sleep(time.Millisecond * 300)
 		}

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func fetchSpotifyStatus() SpotifyStatus {
 
 func onReady() {
 	systray.SetTitle("Loading...")
-	mLyrics := systray.AddMenuItem("Lyrics", "Search lyrics")
+	mLyrics := systray.AddMenuItem("Lyrics", "Search for lyrics online")
 	systray.AddSeparator()
 	mProgress := systray.AddMenuItemCheckbox("Show progress?", "Show Progress", true)
 	mArtistFirst := systray.AddMenuItemCheckbox("Show artist first?", "Show artist first", true)
@@ -145,7 +145,7 @@ func onReady() {
 
 	go func() {
 		<-mLyrics.ClickedCh
-		open.Run("https://www.google.be/search?q=" + currentSpotifyStatus.track + " lyrics")
+		open.Run("https://www.google.be/search?q=" + currentSpotifyStatus.track + "-" + currentSpotifyStatus.artist + " lyrics")
 	}()
 
 	go func() {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type Preferences struct {
+	HasProgress bool
+	ArtistFirst bool
+	MoreSpace   bool
+}
+
+var path = ""
+var preferences = Preferences{
+	HasProgress: true,
+	ArtistFirst: true,
+	MoreSpace:   true,
+}
+
+func Init() {
+	dirname, err := os.UserConfigDir()
+	if err != nil {
+		return
+	}
+
+	path = dirname + "/spotify-tray/preferences.json"
+	fmt.Println(path)
+	readOrWriteFileIfExist(path)
+}
+
+func readOrWriteFileIfExist(fileName string) {
+	_, error := os.Stat(fileName)
+
+	if os.IsNotExist(error) {
+		writeFile()
+	} else {
+		readFile()
+	}
+}
+
+func GetHasProgress() bool {
+	return preferences.HasProgress
+}
+func SetHasProgress(value bool) {
+	preferences.HasProgress = value
+	writeFile()
+}
+
+func GetArtistFirst() bool {
+	return preferences.ArtistFirst
+}
+func SetArtistFirst(value bool) {
+	preferences.ArtistFirst = value
+	writeFile()
+}
+
+func GetMoreSpace() bool {
+	return preferences.MoreSpace
+}
+func SetMoreSpace(value bool) {
+	preferences.MoreSpace = value
+	writeFile()
+}
+
+func readFile() {
+	if len(path) != 0 {
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		preferences = Preferences{}
+		_ = json.Unmarshal(content, &preferences)
+	}
+}
+
+func writeFile() {
+	if len(path) != 0 {
+		content, err := json.Marshal(preferences)
+		if err != nil {
+			return
+		}
+
+		err = ioutil.WriteFile(path, content, 0644)
+
+		if os.IsNotExist(err) {
+			dirname, _ := os.UserConfigDir()
+
+			os.Mkdir(filepath.Join(dirname, "/spotify-tray"), 0755)
+			ioutil.WriteFile(path, content, 0644)
+		}
+	}
+}


### PR DESCRIPTION
add options for `show progress?`, `show artist first?` and `use more data`. These are all enabled by default and are reset when the app is closed. 

In the 3rd commit i have added logic to save to a `preferences.json` file in `$home/Library/Application Support/spotify-tray`. So now the preferences are persisted between launches.

<img width="308" alt="Screenshot 2022-05-14 at 16 27 14" src="https://user-images.githubusercontent.com/27205182/168430036-604ab0a2-fa57-4031-9f99-9204d6b30c6a.png">
