### PR TITLE
Memory leak

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,10 +15,10 @@ import (
 var wg sync.WaitGroup
 
 func main() {
-	selfRestartTimer := time.NewTimer(time.Hour * 8)
+	selfRestartTimer := time.NewTimer(time.Hour * 4)
 	wg.Add(1)
 
-	// Restart every 8 hours to avoid memory build up
+	// Restart every 4 hours to avoid memory build up
 	go func() {
 		defer wg.Done()
 		<-selfRestartTimer.C


### PR DESCRIPTION
Not such a nice fix but restart the process if it has been running for 8 hours to clean up any hanging memory. closes #20. Not sure if we want a fix like this, it's not really visible to the user that the process gets restarted we show a second the `Loading...` again. The process itself also does not shut down, just the underlying go routine is restarted. 

Not sure if this still needed, running the app for a while with changes in #23 and the app is not really rising in memory.